### PR TITLE
Change CI trigger branch from 'release' to 'main' and update docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: "publish"
 on:
   push:
     branches:
-      - release
+      - main
 
 # This workflow will trigger on each push to the `release` branch to create or update a GitHub release, build your app, and upload the artifacts to the release.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,16 @@ Thank you for your interest in contributing to our project! This document provid
 - Check out the [README.md](./README.md) for setup instructions.
 - If you're not sure where to start, look at issues labeled `good first issue` or `help wanted`.
 
+## Branching Strategy
+
+- **`main`**: Stable branch. All production-ready code lives here. Builds and releases are generated from this branch.
+- **`dev`**: Integration branch. All features are merged here before being released.
+- **`feature/*`**: Feature branches for new functionality, improvements, or refactors. Created from `dev`.
+
+
 ## Pull Requests
 1. Fork the repository.
-2. Create a new branch from `main`.
+2. Create a feature branch from `dev`.
 3. Make your changes and commit them.
-4. Push to the branch.
+4. Push to the `dev` branch.
 5. Open a Pull Request.


### PR DESCRIPTION
Update branching strategy in CONTRIBUTING.md with detailed information about main, dev, and feature branches, and update PR instructions to use dev branch