### PR TITLE
Update TypeScript compilation flags in build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc --noEmit --skipLibCheck && vite build",
     "preview": "vite preview",
     "tauri": "tauri"
   },


### PR DESCRIPTION
This pull request updates the build script in the `package.json` file to improve TypeScript checks during the build process.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L8-R8): Modified the `build` script to include the `--noEmit` and `--skipLibCheck` flags in the TypeScript compilation step, ensuring that no files are emitted and library type checks are skipped during the build.