### PR TITLE
Fix/distilled mass

### DIFF
--- a/src-tauri/src/calculations/service.rs
+++ b/src-tauri/src/calculations/service.rs
@@ -96,6 +96,7 @@ impl CalculationService {
 
             if let (Some(x_d0), Some(x_df), Some(x_b0), Some(x_bf)) = (x_d0, x_df, x_b0, x_bf) {
                 if x_b0 > x_0 {
+                    println!("Skipping value: x_b0 = {}; x_0 = {}", x_b0, x_0);
                     continue;
                 }
                 let dx = x_bf - x_b0;

--- a/src/components/initial-values-form.tsx
+++ b/src/components/initial-values-form.tsx
@@ -70,7 +70,7 @@ export function InitialValuesForm({
             render={({ field }) => (
               <FormItem>
                 <FormLabel className="flex items-center gap-2">
-                  Masa inicial (g)
+                  Initial mass (g)
                   <Info className="size-3 self-start" />
                 </FormLabel>
                 <FormControl>
@@ -93,7 +93,7 @@ export function InitialValuesForm({
             render={({ field }) => (
               <FormItem>
                 <FormLabel className="flex items-center gap-2">
-                  Composición (%m/m)
+                  Composition (%m/m)
                   <Info className="size-3 self-start" />
                 </FormLabel>
                 <FormControl>


### PR DESCRIPTION
This pull request introduces a minor logging improvement in the calculation service and updates the user interface text in the initial values form to use English instead of Spanish.

### Logging improvement:
* Added a debug log to skip processing when `x_b0 > x_0` in the `CalculationService` implementation (`src-tauri/src/calculations/service.rs`).

### UI text updates:
* Changed "Masa inicial (g)" to "Initial mass (g)" in the `InitialValuesForm` component (`src/components/initial-values-form.tsx`).
* Changed "Composición (%m/m)" to "Composition (%m/m)" in the `InitialValuesForm` component (`src/components/initial-values-form.tsx`).